### PR TITLE
Updates and translation file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,11 +1,12 @@
 == Version History ==
 
-x.x:
+1.1.1 - 2017-11-29:
+ - enable admins to edit someone else's profile icon access
 
 1.1.0 (10/12/2015):
  - upgrade for Elgg 1.9
  - AMD load js
 
 1.0 (09/10/2012):
-  - initial release
-  - rewritten based on original version for Elgg 1.6 by Curverider
+ - initial release
+ - rewritten based on original version for Elgg 1.6 by Curverider

--- a/actions/profileiconaccess.php
+++ b/actions/profileiconaccess.php
@@ -1,23 +1,22 @@
 <?php
-
 namespace AU\ProfileIconAccess;
 
 $guid = (int) get_input('guid');
 $access = (int) get_input('access');
 $user = get_user($guid);
 
-if (!user || !$user->canEdit()) {
-  register_error(elgg_echo('profileiconaccess:error'));
-  forward();
+if (!$user || !$user->canEdit()) {
+	register_error(elgg_echo('profileiconaccess:error'));
+	forward();
 }
 
-$id = create_metadata($user->guid, 'iconaccess', $access, 'integer', $user->guid, $access);
+// Metadata should be public, so any logged in user can access it and determiner that icon should not be displayed
+$id = create_metadata($user->guid, 'iconaccess', $access, 'integer', $user->guid, 2);
 
 if ($id) {
-  system_message(elgg_echo('profileiconaccess:success'));
-}
-else {
-  register_error(elgg_echo('profileiconaccess:error'));
+	system_message(elgg_echo('profileiconaccess:success'));
+} else {
+	register_error(elgg_echo('profileiconaccess:error'));
 }
 
 forward(REFERER);

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -1,0 +1,8 @@
+<?php
+return array (
+	'profileiconaccess:label' => 'Qui peut voir votre photo de profil (avatar) ?',
+	'profileiconaccess:current:access' => 'Visibilité actuelle : %s',
+	'profileiconaccess:error' => 'Une erreur s\'est produite, la visibilité de votre photo de profil (avatar) n\'a pas pu être enregistrée',
+	'profileiconaccess:success' => 'La visibilité de la photo de profil (avatar) a bien été enregistrée',
+);
+

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin_manifest xmlns="http://www.elgg.org/plugin_manifest/1.8">
-    <name>Profile Icon Access</name>
-    <author>Matt Beckett</author>
-    <version>1.1.0</version>
-    <description>Users can set access on their profile icon, if another user doesn't have access they see the default image</description>
-    <website>https://landing.athabascau.ca</website>
-    <copyright>(C) Athabasca University, 2012</copyright>
-    <license>GNU Public License version 2</license>
- 	
-    <requires>
-        <type>elgg_release</type>
-        <version>1.9</version>
-    </requires>
-	
+	<name>Profile Icon Access</name>
+	<author>Facyla, Matt Beckett, initial work by Curverider</author>
+	<version>1.1.1</version>
+	<description>Users can set access on their profile icon, if another user doesn't have access they see the default image</description>
+	<website>https://landing.athabascau.ca</website>
+	<copyright>(C) Athabasca University, 2012</copyright>
+	<license>GNU Public License version 2</license>
+
+	<requires>
+		<type>elgg_release</type>
+		<version>1.9</version>
+	</requires>
+
 </plugin_manifest>

--- a/views/default/forms/profileiconaccess.php
+++ b/views/default/forms/profileiconaccess.php
@@ -4,19 +4,20 @@ namespace AU\ProfileIconAccess;
 
 elgg_require_js('profileiconaccess');
 
-$user = elgg_get_logged_in_user_entity();
+//$user = elgg_get_logged_in_user_entity();
+$user = elgg_get_page_owner_entity();
 
 $access = ($user->iconaccess === NULL) ? ACCESS_PUBLIC : $user->iconaccess;
 
 
 echo '<div class="profileiconaccess">';
-echo '<label for="profileiconaccess-select">' . elgg_echo('profileiconaccess:label') . ' </label>';
-echo elgg_view('input/access', array(
-			'name' => 'profileaccessicon',
-			'value' => $access,
-			'id' => 'profileiconaccess-select',
-		));
-echo '<div class="profileiconaccess-throbber">';
-echo elgg_view('graphics/ajax_loader');
-echo '</div>';
+	echo '<label for="profileiconaccess-select">' . elgg_echo('profileiconaccess:label') . ' </label>';
+	echo elgg_view('input/access', array(
+				'name' => 'profileaccessicon',
+				'value' => $access,
+				'id' => 'profileiconaccess-select',
+			));
+	echo '<div class="profileiconaccess-throbber">';
+		echo elgg_view('graphics/ajax_loader');
+	echo '</div>';
 echo '</div>';


### PR DESCRIPTION
Hi,

I made a few small changes for several reasons : 
- There was a little typobug in action (missing $ before 'user')
- metadata access was sync with its value : changed to public (so any logged in user can access the meta and display the icon or not dependning on its value - though it should not changed anything in behaviour in most cases)
- value displayed in for used the currently logged in user, which may be an admin (eg. if editing a user's personal settings), which caused inconsistent behaviour (admin would see its own setting, but change the user's setting, which value would never be displayed)

Also added a french translation file.

Have a nice day,
Facyla